### PR TITLE
Back/feat/carusel imgs collection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.ignoreLimitWarning": true
+}

--- a/backend/cms/src/app/(payload)/admin/importMap.js
+++ b/backend/cms/src/app/(payload)/admin/importMap.js
@@ -1,1 +1,5 @@
-export const importMap = {}
+
+
+export const importMap = {
+
+}

--- a/backend/cms/src/collections/SliderImages.ts
+++ b/backend/cms/src/collections/SliderImages.ts
@@ -2,6 +2,9 @@ import { CollectionConfig } from 'payload'
 
 export const SliderImages: CollectionConfig = {
   slug: 'slider-images',
+  access: {
+    read: () => true,
+  },
   admin: {
     useAsTitle: 'title',
   },
@@ -16,12 +19,12 @@ export const SliderImages: CollectionConfig = {
       name: 'title',
       type: 'text',
       required: true,
-      label: 'Opis zdjęcia - co się na nim znajduje?',
+      label: 'Description',
     },
     {
       name: 'isDark',
       type: 'checkbox',
-      label: 'Czy obrazek jest ciemny?',
+      label: 'Dark mode',
       defaultValue: false,
     },
   ],

--- a/backend/cms/src/collections/SliderImages.ts
+++ b/backend/cms/src/collections/SliderImages.ts
@@ -1,0 +1,28 @@
+import { CollectionConfig } from 'payload'
+
+export const SliderImages: CollectionConfig = {
+  slug: 'slider-images',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'image',
+      type: 'upload',
+      relationTo: 'media',
+      required: true,
+    },
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+      label: 'Opis zdjęcia - co się na nim znajduje?',
+    },
+    {
+      name: 'isDark',
+      type: 'checkbox',
+      label: 'Czy obrazek jest ciemny?',
+      defaultValue: false,
+    },
+  ],
+}

--- a/backend/cms/src/payload-types.ts
+++ b/backend/cms/src/payload-types.ts
@@ -6,23 +6,93 @@
  * and re-run `payload generate:types` to regenerate this file.
  */
 
+/**
+ * Supported timezones in IANA format.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "supportedTimezones".
+ */
+export type SupportedTimezones =
+  | 'Pacific/Midway'
+  | 'Pacific/Niue'
+  | 'Pacific/Honolulu'
+  | 'Pacific/Rarotonga'
+  | 'America/Anchorage'
+  | 'Pacific/Gambier'
+  | 'America/Los_Angeles'
+  | 'America/Tijuana'
+  | 'America/Denver'
+  | 'America/Phoenix'
+  | 'America/Chicago'
+  | 'America/Guatemala'
+  | 'America/New_York'
+  | 'America/Bogota'
+  | 'America/Caracas'
+  | 'America/Santiago'
+  | 'America/Buenos_Aires'
+  | 'America/Sao_Paulo'
+  | 'Atlantic/South_Georgia'
+  | 'Atlantic/Azores'
+  | 'Atlantic/Cape_Verde'
+  | 'Europe/London'
+  | 'Europe/Berlin'
+  | 'Africa/Lagos'
+  | 'Europe/Athens'
+  | 'Africa/Cairo'
+  | 'Europe/Moscow'
+  | 'Asia/Riyadh'
+  | 'Asia/Dubai'
+  | 'Asia/Baku'
+  | 'Asia/Karachi'
+  | 'Asia/Tashkent'
+  | 'Asia/Calcutta'
+  | 'Asia/Dhaka'
+  | 'Asia/Almaty'
+  | 'Asia/Jakarta'
+  | 'Asia/Bangkok'
+  | 'Asia/Shanghai'
+  | 'Asia/Singapore'
+  | 'Asia/Tokyo'
+  | 'Asia/Seoul'
+  | 'Australia/Brisbane'
+  | 'Australia/Sydney'
+  | 'Pacific/Guam'
+  | 'Pacific/Noumea'
+  | 'Pacific/Auckland'
+  | 'Pacific/Fiji';
+
 export interface Config {
   auth: {
     users: UserAuthOperations;
   };
+  blocks: {};
   collections: {
     users: User;
     media: Media;
+    'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
+  };
+  collectionsJoins: {};
+  collectionsSelect: {
+    users: UsersSelect<false> | UsersSelect<true>;
+    media: MediaSelect<false> | MediaSelect<true>;
+    'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
+    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
+    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
     defaultIDType: string;
   };
   globals: {};
+  globalsSelect: {};
   locale: null;
   user: User & {
     collection: 'users';
+  };
+  jobs: {
+    tasks: unknown;
+    workflows: unknown;
   };
 }
 export interface UserAuthOperations {
@@ -81,6 +151,29 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-locked-documents".
+ */
+export interface PayloadLockedDocument {
+  id: string;
+  document?:
+    | ({
+        relationTo: 'users';
+        value: string | User;
+      } | null)
+    | ({
+        relationTo: 'media';
+        value: string | Media;
+      } | null);
+  globalSlug?: string | null;
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
@@ -112,6 +205,71 @@ export interface PayloadMigration {
   batch?: number | null;
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users_select".
+ */
+export interface UsersSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media_select".
+ */
+export interface MediaSelect<T extends boolean = true> {
+  alt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-locked-documents_select".
+ */
+export interface PayloadLockedDocumentsSelect<T extends boolean = true> {
+  document?: T;
+  globalSlug?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-preferences_select".
+ */
+export interface PayloadPreferencesSelect<T extends boolean = true> {
+  user?: T;
+  key?: T;
+  value?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-migrations_select".
+ */
+export interface PayloadMigrationsSelect<T extends boolean = true> {
+  name?: T;
+  batch?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/backend/cms/src/payload-types.ts
+++ b/backend/cms/src/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     users: User;
     media: Media;
+    'slider-images': SliderImage;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -77,6 +78,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    'slider-images': SliderImagesSelect<false> | SliderImagesSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -151,6 +153,18 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "slider-images".
+ */
+export interface SliderImage {
+  id: string;
+  image: string | Media;
+  title: string;
+  isDark?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -163,6 +177,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media';
         value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'slider-images';
+        value: string | SliderImage;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -238,6 +256,17 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "slider-images_select".
+ */
+export interface SliderImagesSelect<T extends boolean = true> {
+  image?: T;
+  title?: T;
+  isDark?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/backend/cms/src/payload.config.ts
+++ b/backend/cms/src/payload.config.ts
@@ -9,6 +9,7 @@ import sharp from 'sharp'
 
 import { Users } from './collections/Users'
 import { Media } from './collections/Media'
+import { SliderImages } from './collections/SliderImages'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -20,7 +21,8 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media],
+  cors: ['http://localhost:5173'],
+  collections: [Users, Media, SliderImages],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {

--- a/backend/cms/tsconfig.json
+++ b/backend/cms/tsconfig.json
@@ -30,7 +30,7 @@
         "./src/payload.config.ts"
       ]
     },
-    "target": "ES2022",
+    "target": "ES2022"
   },
   "include": [
     "next-env.d.ts",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@eslint/js": "^9.25.0",
+        "@types/node": "^22.15.24",
         "@types/react": "^19.1.4",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -1464,6 +1465,16 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.24.tgz",
+      "integrity": "sha512-w9CZGm9RDjzTh/D+hFwlBJ3ziUaVw7oufKA3vOFSOZlzmW9AkZnfjPb+DLnrV6qtgL/LNmP0/2zBNCFHL3F0ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -3327,6 +3338,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@eslint/js": "^9.25.0",
+    "@types/node": "^22.15.24",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import "./App.css";
 // import arch_sketch from "./assets/arch_sketch.jpg";
-import { Carousel } from "./components/Carusel/Carusel";
+import { Slider } from "./components/Slider/Slider";
 import { NavbarAlt } from "./components/Navbar_alt/NavbarAlt";
 
 // const bgImageStyle = {
@@ -18,7 +18,7 @@ function App() {
       {/* <div style={bgImageStyle} className="fade-in"> */}
       {/* <Navbar />/> */}
       <NavbarAlt />
-      <Carousel />
+      <Slider />
       <main
         style={{
           top: 0,

--- a/frontend/src/components/Slider/Slider.tsx
+++ b/frontend/src/components/Slider/Slider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import styled from "@emotion/styled";
-import sliderImgData from "../../data/sliderImgData";
+import type { SliderImage } from "../../types/slider";
+import { fetchSliderImages } from "../../utils/fetchSliderImages";
 
 const SliderWrapper = styled.div`
   top: 0;
@@ -29,21 +30,30 @@ const Slide = styled.div`
 `;
 
 export const Slider = () => {
-  const images = sliderImgData;
+  const [images, setImages] = useState<SliderImage[]>([]);
   const [index, setIndex] = useState(1);
   const [transition, setTransition] = useState(true);
 
-  const loopedImages = [images[images.length - 1], ...images, images[0]];
+  useEffect(() => {
+    fetchSliderImages().then(setImages);
+  }, []);
+
+  const loopedImages = images.length
+    ? [images[images.length - 1], ...images, images[0]]
+    : [];
 
   useEffect(() => {
+    if (!images.length) return;
     const interval = setInterval(() => {
       setIndex((prev) => prev + 1);
       setTransition(true);
     }, 5000);
     return () => clearInterval(interval);
-  }, []);
+  }, [images]);
 
   useEffect(() => {
+    if (!images.length) return;
+
     if (index === images.length + 1) {
       const timer = setTimeout(() => {
         setTransition(false);
@@ -58,8 +68,7 @@ export const Slider = () => {
       }, 1000);
       return () => clearTimeout(timer);
     }
-  }, [index]);
-  console.log("Loaded images:", sliderImgData);
+  }, [index, images]);
 
   return (
     <SliderWrapper>
@@ -68,9 +77,10 @@ export const Slider = () => {
           <Slide
             key={i}
             style={{ backgroundImage: `url(${img.url})` }}
-            aria-label={img.alt}
-            title={img.title}
-          />
+            aria-label={img.title}
+          >
+            <img src={img.url} alt={img.title} style={{ display: "none" }} />
+          </Slide>
         ))}
       </Track>
     </SliderWrapper>

--- a/frontend/src/components/Slider/Slider.tsx
+++ b/frontend/src/components/Slider/Slider.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import sliderImgData from "../../data/sliderImgData";
 
-const CarouselWrapper = styled.div`
+const SliderWrapper = styled.div`
   top: 0;
   left: 0;
   width: 100vw;
@@ -28,7 +28,7 @@ const Slide = styled.div`
   background-position: center;
 `;
 
-export const Carousel = () => {
+export const Slider = () => {
   const images = sliderImgData;
   const [index, setIndex] = useState(1);
   const [transition, setTransition] = useState(true);
@@ -62,7 +62,7 @@ export const Carousel = () => {
   console.log("Loaded images:", sliderImgData);
 
   return (
-    <CarouselWrapper>
+    <SliderWrapper>
       <Track translateX={-index * 100} transition={transition}>
         {loopedImages.map((img, i) => (
           <Slide
@@ -73,6 +73,6 @@ export const Carousel = () => {
           />
         ))}
       </Track>
-    </CarouselWrapper>
+    </SliderWrapper>
   );
 };

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,0 +1,2 @@
+export const BASE_URL =
+  import.meta.env.VITE_API_BASE || "http://localhost:3000";

--- a/frontend/src/types/slider.ts
+++ b/frontend/src/types/slider.ts
@@ -1,0 +1,13 @@
+export type SliderImage = {
+  url: string;
+  title: string;
+  isDark: boolean;
+};
+
+export type RawSliderImage = {
+  image: {
+    url: string;
+  };
+  title: string;
+  isDark: boolean;
+};

--- a/frontend/src/utils/fetchSliderImages.ts
+++ b/frontend/src/utils/fetchSliderImages.ts
@@ -1,0 +1,13 @@
+import type { RawSliderImage, SliderImage } from "../types/slider";
+
+export const fetchSliderImages = async (): Promise<SliderImage[]> => {
+  const res = await fetch("http://localhost:3000/api/slider-images?depth=1");
+  const data: { docs: RawSliderImage[] } = await res.json();
+
+  return data.docs.map((doc) => ({
+    url: doc.image.url,
+    title: doc.title,
+    alt: doc.title,
+    isDark: doc.isDark,
+  }));
+};

--- a/frontend/src/utils/fetchSliderImages.ts
+++ b/frontend/src/utils/fetchSliderImages.ts
@@ -1,11 +1,19 @@
+import { BASE_URL } from "../config/api";
 import type { RawSliderImage, SliderImage } from "../types/slider";
 
 export const fetchSliderImages = async (): Promise<SliderImage[]> => {
-  const res = await fetch("http://localhost:3000/api/slider-images?depth=1");
+  const res = await fetch(`${BASE_URL}/api/slider-images?depth=1`);
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch slider images: ${res.status} ${res.statusText}`
+    );
+  }
+
   const data: { docs: RawSliderImage[] } = await res.json();
 
   return data.docs.map((doc) => ({
-    url: doc.image.url,
+    url: `${BASE_URL}${doc.image.url}`,
     title: doc.title,
     alt: doc.title,
     isDark: doc.isDark,


### PR DESCRIPTION
This PR replaces static image data with a dynamic integration using Payload CMS + MongoDB to power the homepage slider (formerly Carousel). The admin can now upload and manage slider images via the CMS panel.

Key Changes:
1. Renamed Carousel component to Slider for clarity
2. Created a new SliderImages collection in Payload (title, image, isDark)
3. Implemented fetchSliderImages util to fetch data from Payload API
4. Updated Slider.tsx to render images dynamically from CMS
5. Extracted shared types to types/slider.ts
6. Added fallback and error handling for API fetch
7. Ensured correct CORS setup for local dev (and tested with real uploads)

