### PR TITLE
Back/feat/payload deploy

### DIFF
--- a/backend/cms/Dockerfile
+++ b/backend/cms/Dockerfile
@@ -1,71 +1,40 @@
-# To use this Dockerfile, you have to set `output: 'standalone'` in your next.config.mjs file.
-# From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
-
+# Base image
 FROM node:22.12.0-alpine AS base
 
-# Install dependencies only when needed
+# Dependencies layer
 FROM base AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
-RUN \
-  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+COPY package.json pnpm-lock.yaml ./
 
+RUN corepack enable && pnpm install --frozen-lockfile
 
-# Rebuild the source code only when needed
+# Build layer
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED 1
+RUN corepack enable && pnpm run build
 
-RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
-
-# Production image, copy all the files and run next
+# Production layer
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-# Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV PORT=3000
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
 
-# Remove this line if you do not have this folder
 COPY --from=builder /app/public ./public
+RUN mkdir .next && chown nextjs:nodejs .next
 
-# Set the correct permission for prerender cache
-RUN mkdir .next
-RUN chown nextjs:nodejs .next
-
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
 EXPOSE 3000
-
-ENV PORT 3000
-
-# server.js is created by next build from the standalone output
-# https://nextjs.org/docs/pages/api-reference/next-config-js/output
-CMD HOSTNAME="0.0.0.0" node server.js
+CMD ["node", "server.js"]

--- a/backend/cms/Dockerfile
+++ b/backend/cms/Dockerfile
@@ -1,40 +1,16 @@
-# Base image
-FROM node:22.12.0-alpine AS base
+FROM node:18-alpine
 
-# Dependencies layer
-FROM base AS deps
-RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
-
 RUN corepack enable && pnpm install --frozen-lockfile
 
-# Build layer
-FROM base AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN corepack enable && pnpm run build
-
-# Production layer
-FROM base AS runner
-WORKDIR /app
+RUN pnpm run build
 
 ENV NODE_ENV=production
 ENV PORT=3000
-
-RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nextjs
-
-COPY --from=builder /app/public ./public
-RUN mkdir .next && chown nextjs:nodejs .next
-
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-USER nextjs
-
 EXPOSE 3000
-CMD ["node", "server.js"]
+
+CMD ["pnpm", "payload", "serve"]

--- a/backend/cms/next.config.mjs
+++ b/backend/cms/next.config.mjs
@@ -2,7 +2,7 @@ import { withPayload } from '@payloadcms/next/withPayload'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Your Next.js config here
+  output: 'standalone',
 }
 
 export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/backend/cms/next.config.mjs
+++ b/backend/cms/next.config.mjs
@@ -1,8 +1,0 @@
-import { withPayload } from '@payloadcms/next/withPayload'
-
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: 'standalone',
-}
-
-export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/backend/cms/package.json
+++ b/backend/cms/package.json
@@ -4,28 +4,21 @@
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",
-  "scripts": {
-    "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
-    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
-    "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
-    "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
-    "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",
-    "lint": "cross-env NODE_OPTIONS=--no-deprecation next lint",
-    "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
-    "start": "cross-env NODE_OPTIONS=--no-deprecation next start"
-  },
+"scripts": {
+  "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
+  "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
+  "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",
+  "dev": "pnpm payload dev",
+  "build": "pnpm run generate:types && pnpm run generate:importmap"
+},
   "dependencies": {
     "@payloadcms/db-mongodb": "3.39.1",
-    "@payloadcms/next": "3.39.1",
     "@payloadcms/payload-cloud": "3.39.1",
     "@payloadcms/richtext-lexical": "3.39.1",
     "@payloadcms/ui": "3.39.1",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",
-    "next": "15.3.0",
     "payload": "3.39.1",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
     "sharp": "0.32.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove Next.js and frontend dependencies to deploy standalone Payload CMS

- Removed `next`, `react`, and related build scripts
- Replaced Dockerfile with a minimal one targeting pure Payload CMS
- Cleaned up `package.json` to only include Payload logic
- Set up `pnpm` as package manager with lockfile support
- Ensured compatibility with Render deployment

This version focuses on making the CMS panel remotely accessible without needing the frontend or Next.js integration.
